### PR TITLE
Version bump OpenTDD to 15.1 and add dev environment config for nix. 

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ pom.xml.versionsBackup
 release.properties
 server
 out
+
+
+# NixOS
+.direnv/

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ The following table shows which docker image contains which OpenTTD version. For
 
 | Container                        | OpenTTD |
 |----------------------------------|---------|
-| hauschi86/openttd-server:latest  | 15.0    |
+| hauschi86/openttd-server:latest  | 15.1    |
+| hauschi86/openttd-server:v15.1.0 | 15.1    |
 | hauschi86/openttd-server:v15.0.2 | 15.0    |
 | hauschi86/openttd-server:v15.0.0 | 15.0    |
 | hauschi86/openttd-server:v14.1.1 | 14.1    |

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1769461804,
+        "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,69 @@
+{
+  description = "OpenTTD Server development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        # Node.js 24.12.0 to match pom.xml
+        nodejs-24_12_0 = pkgs.stdenv.mkDerivation rec {
+          pname = "nodejs";
+          version = "24.12.0";
+
+          src = pkgs.fetchurl {
+            url = "https://nodejs.org/dist/v${version}/node-v${version}-linux-x64.tar.xz";
+            sha256 = "sha256-vevuJ25Y0O9USPPVrBLGfaqWPdXgqbtiGlPRzvvIUv0=";
+          };
+
+          nativeBuildInputs = [ pkgs.autoPatchelfHook ];
+          buildInputs = [ pkgs.stdenv.cc.cc.lib ];
+
+          installPhase = ''
+            mkdir -p $out
+            cp -r * $out/
+          '';
+        };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            # Java 17 (matches Dockerfile)
+            jdk17
+            maven
+
+            # Node.js 24.12.0 for frontend build (matches pom.xml)
+            nodejs-24_12_0
+
+            # Docker for building and running containers
+            docker
+            docker-compose
+
+            # Useful utilities
+            curl
+            wget
+          ];
+
+          shellHook = ''
+            export JAVA_HOME="${pkgs.jdk17}"
+
+            # Setup node symlinks for frontend-maven-plugin
+            mkdir -p ui/node/node_modules
+            ln -sf ${nodejs-24_12_0}/bin/node ui/node/node
+            ln -sf ${nodejs-24_12_0}/lib/node_modules/npm ui/node/node_modules/npm
+            ln -sf ${nodejs-24_12_0}/lib/node_modules/npm/bin/npm-cli.js ui/node/npm
+
+            echo "OpenTTD Server dev environment loaded"
+            echo "Java: $(java -version 2>&1 | head -1)"
+            echo "Maven: $(mvn -version 2>&1 | head -1)"
+            echo "Node: $(node --version)"
+          '';
+        };
+      }
+    );
+}

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -47,19 +47,19 @@ RUN passwd -d openttd
 USER openttd
 WORKDIR /home/openttd
 
-RUN wget https://cdn.openttd.org/openttd-releases/15.0/openttd-15.0-linux-generic-amd64.tar.xz
+RUN wget https://cdn.openttd.org/openttd-releases/15.1/openttd-15.1-linux-generic-amd64.tar.xz
 RUN wget https://cdn.openttd.org/opengfx-releases/8.0/opengfx-8.0-all.zip
 
-RUN tar -xf openttd-15.0-linux-generic-amd64.tar.xz
+RUN tar -xf openttd-15.1-linux-generic-amd64.tar.xz
 
 RUN mkdir openttd-15
-RUN cp -a openttd-15.0-linux-generic-amd64/. openttd-15
+RUN cp -a openttd-15.1-linux-generic-amd64/. openttd-15
 RUN mkdir openttd-15/newgrf
 
 RUN unzip opengfx-8.0-all.zip
 RUN tar -xf opengfx-8.0.tar -C openttd-15/baseset/
 
-RUN rm -rf opengfx-*.tar opengfx-*.zip openttd-15.0*
+RUN rm -rf opengfx-*.tar opengfx-*.zip openttd-15.1*
     ## Set entrypoint script to right user
 RUN chmod +x /openttd.sh
 


### PR DESCRIPTION
This PR primarily bumps OpenTDD to 15.1 from the same upstream and also updates the readme in anticipation of the new docker tags (worth checking). 

Secondly - it introduces a declarative & contained development environment to successfully build and test locally. This is achieved through a flake and using nix. 

This allowed me to successfully build against versions of node and java that were expected - without my system-wide versions interfering. Also helped me avoid version bumping more than was necessary within the code. 

This resolves #20 